### PR TITLE
Avoid commenting on bot PRs

### DIFF
--- a/pkg/handler/pullrequest/handler.go
+++ b/pkg/handler/pullrequest/handler.go
@@ -64,7 +64,9 @@ func openOrSync(gitRepo *git.Git, pr *github.PullRequestPayload, ghClient *goGit
 
 	// If the pull request is coming from a local branch
 	if pr.PullRequest.Base.Repo.FullName == pr.PullRequest.Head.Repo.FullName {
-		if pr.Action == "opened" {
+		// We only comment if the PR isn't from a bot, to avoid affecting their behaviour
+		// (e.g. dependabot stops maintaining PRs automatically if they're commented)
+		if pr.Action == "opened" && pr.PullRequest.User.Type != "Bot" {
 			commentOnPR(pr, ghClient,
 				"I see This pr is using the local branch workflow, ignoring it on my side, have fun!")
 		}


### PR DESCRIPTION
Some bots react to PR comments, for example dependabot stops
auto-updating PRs. This patch ensures that PRs from bots on local
branches don’t receive a comment.

Signed-off-by: Stephen Kitt <skitt@redhat.com>