### PR TITLE
Add config file capability to label action

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	golang.org/x/crypto v0.0.0-20191205180655-e7c4368fe9dd
 	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a
 	gopkg.in/src-d/go-git.v4 v4.13.1
+	gopkg.in/yaml.v2 v2.2.1
 	k8s.io/api v0.0.0-20190620084959-7cf5895f2711
 	k8s.io/apimachinery v0.0.0-20190612205821-1799e75a0719
 	k8s.io/client-go v0.0.0-20190620085101-78d2af792bab

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -65,19 +65,14 @@ func (git *Git) EnsureRemote(name, url string) error {
 	git.repo.DeleteRemote(name)
 	git.repo.CreateRemote(&gogitConfig.RemoteConfig{Name: name, URLs: []string{url}})
 	klog.Infof("Remote %s ensured from %s", name, url)
-	err := git.FetchRemote(name)
 
-	return err
-}
-
-func (git *Git) FetchRemote(name string) error {
 	err := git.repo.Fetch(&gogit.FetchOptions{RemoteName: name, Auth: git.auth})
 	if err == nil || err.Error() == "already up-to-date" {
 		klog.Infof("Remote %s fetched", name)
 		return nil
-	} else {
-		klog.Errorf("Issue fetching remote %s : %s", name, err)
 	}
+
+	klog.Errorf("Issue fetching remote %s : %s", name, err)
 	return err
 }
 
@@ -111,10 +106,7 @@ func (git *Git) GetBranches() (Branches, error) {
 }
 
 func (gitRepo *Git) CreateBranch(versionBranch, sha string) error {
-	return gitRepo.CreateRef("refs/heads/"+versionBranch, sha)
-}
-
-func (gitRepo *Git) CreateRef(refStr, sha string) error {
+	refStr := "refs/heads/" + versionBranch
 	ref := plumbing.ReferenceName(refStr)
 	refHash, err := getHash(sha)
 	if err != nil {
@@ -143,12 +135,9 @@ func getHash(sha string) (plumbing.Hash, error) {
 }
 
 func (gitRepo *Git) Push(versionBranch string) error {
-	return gitRepo.PushRef(origin, "refs/heads/"+versionBranch)
-}
-
-func (gitRepo *Git) PushRef(remote, ref string) error {
+	ref := "refs/heads/" + versionBranch
 	pushOptions := gogit.PushOptions{
-		RemoteName: remote,
+		RemoteName: origin,
 		Auth:       gitRepo.auth,
 		RefSpecs: []gogitConfig.RefSpec{
 			gogitConfig.RefSpec(fmt.Sprintf("+%s:%s", ref, ref))},

--- a/pkg/handler/pullrequest/handler.go
+++ b/pkg/handler/pullrequest/handler.go
@@ -78,7 +78,7 @@ func openOrSync(gitRepo *git.Git, pr *github.PullRequestPayload, gh ghclient.GH)
 		return err
 	}
 
-	branches, err := gitRepo.GetBranches(git.Origin)
+	branches, err := gitRepo.GetBranches()
 	if err != nil {
 		klog.Errorf("Error getting branches for origin repo")
 		return nil
@@ -98,7 +98,7 @@ func openOrSync(gitRepo *git.Git, pr *github.PullRequestPayload, gh ghclient.GH)
 
 	klog.Infof(infoMsg)
 
-	if err = gitRepo.Push(git.Origin, versionBranch); err != nil {
+	if err = gitRepo.Push(versionBranch); err != nil {
 		klog.Errorf("Error pushing origin with the new branch: %s", err)
 		gh.CommentOnPR(prNum, "I had an issue pushing the updated branch: %s", err)
 		return err
@@ -141,7 +141,7 @@ func closeBranches(gitRepo *git.Git, prPayload *github.PullRequestPayload, gh gh
 		return err
 	}
 
-	branches, err := gitRepo.GetBranches(git.Origin)
+	branches, err := gitRepo.GetBranches()
 	if err != nil {
 		klog.Errorf("Error getting branches for origin repo")
 		return nil
@@ -154,7 +154,7 @@ func closeBranches(gitRepo *git.Git, prPayload *github.PullRequestPayload, gh gh
 		return err
 	}
 
-	if err = gitRepo.DeleteRemoteBranches(git.Origin, branchesToDelete); err != nil {
+	if err = gitRepo.DeleteRemoteBranches(branchesToDelete); err != nil {
 		klog.Errorf("Something happened removing branches: %s", err)
 	} else {
 		gh.CommentOnPR(prNum, "Closed branches: %s", branchesToDelete)

--- a/pkg/handler/pullrequestreview.go
+++ b/pkg/handler/pullrequestreview.go
@@ -1,11 +1,27 @@
 package handler
 
 import (
+	"fmt"
+
 	"github.com/go-playground/webhooks/github"
+	"gopkg.in/yaml.v2"
 	"k8s.io/klog"
 
 	"github.com/submariner-io/pr-brancher-webhook/pkg/ghclient"
+	"github.com/submariner-io/pr-brancher-webhook/pkg/git"
 )
+
+const (
+	defaultApprovals = 2
+	defaultLabel     = "ready-to-test"
+)
+
+type botConfig struct {
+	LabelApproved *struct {
+		Approvals *int
+		Label     *string
+	} `yaml:"label-approved"`
+}
 
 func handlePullRequestReview(prr github.PullRequestReviewPayload) error {
 	prNum := int(prr.PullRequest.Number)
@@ -13,6 +29,17 @@ func handlePullRequestReview(prr github.PullRequestReviewPayload) error {
 	if err != nil {
 		klog.Errorf("creating github client: %s", err)
 		return err
+	}
+
+	config, err := readConfig(prr)
+	if err != nil {
+		klog.Errorf("reading bot config: %s", err)
+		return err
+	}
+
+	if config.LabelApproved == nil {
+		klog.Infof("label when approved not enabled in bot config for PR %s/#d", prr.Repository.Owner.Login, prr.PullRequest.Number)
+		return nil
 	}
 
 	reviews, err := gh.ListReviews(prNum)
@@ -28,8 +55,8 @@ func handlePullRequestReview(prr github.PullRequestReviewPayload) error {
 		}
 	}
 
-	if approvals > 1 {
-		err := gh.AddLabel(prNum, "ready-to-test")
+	if approvals >= *config.LabelApproved.Approvals {
+		err := gh.AddLabel(prNum, *config.LabelApproved.Label)
 		if err != nil {
 			klog.Errorf("adding label to pull request: %s", err)
 			return err
@@ -37,4 +64,47 @@ func handlePullRequestReview(prr github.PullRequestReviewPayload) error {
 	}
 
 	return nil
+}
+
+func readConfig(prr github.PullRequestReviewPayload) (*botConfig, error) {
+	gitRepo, err := git.New(prr.PullRequest.Base.Repo.FullName, prr.PullRequest.Base.Repo.SSHURL)
+	if err != nil {
+		return nil, err
+	}
+
+	err = gitRepo.EnsureRemote(prr.PullRequest.User.Login, prr.PullRequest.Head.Repo.SSHURL)
+	if err != nil {
+		return nil, err
+	}
+
+	gitRepo.CheckoutHash(prr.PullRequest.Head.Sha)
+	if err != nil {
+		return nil, err
+	}
+
+	filename := ".submarinerbot.yaml"
+	buf, err := gitRepo.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	config := &botConfig{}
+	err = yaml.Unmarshal(buf, config)
+	if err != nil {
+		return nil, fmt.Errorf("in file %q: %v", filename, err)
+	}
+
+	if config.LabelApproved != nil {
+		if config.LabelApproved.Approvals == nil {
+			v := defaultApprovals
+			config.LabelApproved.Approvals = &v
+		}
+
+		if config.LabelApproved.Label == nil {
+			v := defaultLabel
+			config.LabelApproved.Label = &v
+		}
+	}
+
+	return config, nil
 }


### PR DESCRIPTION
Now the bot will only label if it's instructed to (with some defaults) on the actual repo the pull request is on.