### PR TITLE
Avoid concurrent access to /tmp/<repo> by requests

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"sync"
+
 	"github.com/go-playground/webhooks/github"
 
 	"github.com/submariner-io/pr-brancher-webhook/pkg/handler/pullrequest"
@@ -18,9 +20,33 @@ func Handle(payload interface{}) error {
 	switch payload.(type) {
 
 	case github.PullRequestPayload:
-		return pullrequest.Handle(payload.(github.PullRequestPayload))
+		pr := payload.(github.PullRequestPayload)
+		mutex := getMutex(pr.PullRequest.Base.Repo.FullName)
+		mutex.Lock()
+		defer mutex.Unlock()
+		return pullrequest.Handle(pr)
+
 	case github.PullRequestReviewPayload:
-		return handlePullRequestReview(payload.(github.PullRequestReviewPayload))
+		prReview := payload.(github.PullRequestReviewPayload)
+		mutex := getMutex(prReview.PullRequest.Base.Repo.FullName)
+		mutex.Lock()
+		defer mutex.Unlock()
+		return handlePullRequestReview(prReview)
 	}
 	return nil
+}
+
+var repoMutexMap map[string]sync.Mutex
+var repoMutex sync.Mutex
+
+func getMutex(repoName string) sync.Mutex {
+	repoMutex.Lock()
+	defer repoMutex.Unlock()
+
+	if mutex, ok := repoMutexMap[repoName]; ok {
+		return mutex
+	}
+
+	repoMutexMap[repoName] = sync.Mutex{}
+	return repoMutexMap[repoName]
 }


### PR DESCRIPTION
An alternative to this would be in-memory git, but
I suspect that would be slower because we would need
to re-download the whole repos every time.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>