### PR TITLE
Make sure Git access is synchronized

### DIFF
--- a/pkg/handler/pullrequest/handler.go
+++ b/pkg/handler/pullrequest/handler.go
@@ -30,6 +30,9 @@ func Handle(pr github.PullRequestPayload) error {
 		return err
 	}
 
+	gitRepo.Lock()
+	defer gitRepo.Unlock()
+
 	switch pr.Action {
 	case "opened":
 		return openOrSync(gitRepo, &pr, gh)

--- a/pkg/handler/pullrequestreview.go
+++ b/pkg/handler/pullrequestreview.go
@@ -80,6 +80,9 @@ func readConfig(prr github.PullRequestReviewPayload) (*botConfig, error) {
 		return nil, err
 	}
 
+	gitRepo.Lock()
+	defer gitRepo.Unlock()
+
 	err = gitRepo.EnsureRemote(prr.PullRequest.User.Login, prr.PullRequest.Head.Repo.SSHURL)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Since we're working on the same directory in the filesystem, we need to
make sure access is synchronized.

Otherwise, multiple events on the same repo can mess up the state.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>