### PR TITLE
Read bot config from the base commit

### DIFF
--- a/pkg/handler/pullrequestreview.go
+++ b/pkg/handler/pullrequestreview.go
@@ -88,7 +88,7 @@ func readConfig(prr github.PullRequestReviewPayload) (*botConfig, error) {
 		return nil, err
 	}
 
-	gitRepo.CheckoutHash(prr.PullRequest.Head.Sha)
+	gitRepo.CheckoutHash(prr.PullRequest.Base.Sha)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We don't want the PR influencing the bot's behavior, read the config
that is merged.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>