### PR TITLE
Avoid inter-lock when accessing the Git Object

### DIFF
--- a/pkg/config/repoconfig/repoconfig.go
+++ b/pkg/config/repoconfig/repoconfig.go
@@ -12,7 +12,7 @@ const (
 	defaultApprovals = 2
 	defaultLabel     = "ready-to-test"
 	filename         = ".submarinerbot.yaml"
-	)
+)
 
 type BotConfig struct {
 	LabelApproved *struct {
@@ -21,22 +21,9 @@ type BotConfig struct {
 	} `yaml:"label-approved"`
 }
 
+func Read(gitRepo *git.Git, sha string) (*BotConfig, error) {
 
-func Read(url, repo, sha string) (*BotConfig, error) {
-	gitRepo, err := git.New(repo, url)
-	if err != nil {
-		return nil, err
-	}
-
-	gitRepo.Lock()
-	defer gitRepo.Unlock()
-
-	err = gitRepo.EnsureRemote(git.Origin, url)
-	if err != nil {
-		return nil, err
-	}
-
-	err = gitRepo.CheckoutHash(sha)
+	err := gitRepo.CheckoutHash(sha)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/handler/pullrequest/handler.go
+++ b/pkg/handler/pullrequest/handler.go
@@ -66,14 +66,14 @@ func logPullRequestInfo(pr *github.PullRequestPayload) {
 func openOrSync(gitRepo *git.Git, pr *github.PullRequestPayload, gh ghclient.GH) error {
 	prNum := int(pr.Number)
 
-	config, err := repoconfig.Read(pr.PullRequest.Base.Repo.SSHURL, pr.PullRequest.Base.Repo.FullName, pr.PullRequest.Base.Sha)
+	config, err := repoconfig.Read(gitRepo, pr.PullRequest.Base.Sha)
 	if err != nil {
 		klog.Infof("Error reading bot config: %s", err)
 	}
 
 	readyToReviewMsg := ""
 	if config != nil && config.LabelApproved != nil {
-		readyToReviewMsg += fmt.Sprintf("\n🚀 Full E2E won't run until the %q label is applied. " +
+		readyToReviewMsg += fmt.Sprintf("\n🚀 Full E2E won't run until the %q label is applied. "+
 			"I will add it automatically once the PR has %d approvals, or you can add it manually.",
 			*config.LabelApproved.Label, config.LabelApproved.Approvals)
 	}
@@ -83,7 +83,7 @@ func openOrSync(gitRepo *git.Git, pr *github.PullRequestPayload, gh ghclient.GH)
 		// We only comment if the PR isn't from a bot, to avoid affecting their behaviour
 		// (e.g. dependabot stops maintaining PRs automatically if they're commented)
 		if pr.Action == "opened" && pr.PullRequest.User.Type != "Bot" {
-			gh.CommentOnPR(prNum, "I see this PR is using the local branch workflow, ignoring it on my side, have fun!" + readyToReviewMsg)
+			gh.CommentOnPR(prNum, "I see this PR is using the local branch workflow, ignoring it on my side, have fun!"+readyToReviewMsg)
 		}
 		return nil
 	}


### PR DESCRIPTION
Otherwise we lock it, then we try to read the config
and that's the end of that thread.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>