### PR TITLE
Display required approvals correctly

### DIFF
--- a/pkg/handler/pullrequest/handler.go
+++ b/pkg/handler/pullrequest/handler.go
@@ -75,7 +75,7 @@ func openOrSync(gitRepo *git.Git, pr *github.PullRequestPayload, gh ghclient.GH)
 	if config != nil && config.LabelApproved != nil {
 		readyToReviewMsg += fmt.Sprintf("\n🚀 Full E2E won't run until the %q label is applied. "+
 			"I will add it automatically once the PR has %d approvals, or you can add it manually.",
-			*config.LabelApproved.Label, config.LabelApproved.Approvals)
+			*config.LabelApproved.Label, *config.LabelApproved.Approvals)
 	}
 
 	// If the pull request is coming from a local branch


### PR DESCRIPTION
Currently, the bot produces messages such as

I will add it automatically once the PR has 824716949408 approvals,

because the value passed for the message's "%d" argument is a
pointer. Fix this by dereferencing the value.

Signed-off-by: Stephen Kitt <skitt@redhat.com>