### PR TITLE
Fix Go linting error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .dapper
 .project
 .settings
+.idea
 *.coverprofile
 /Dockerfile.*
 Makefile.*

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -162,9 +162,7 @@ func getHash(sha string) (plumbing.Hash, error) {
 		return plumbing.Hash{}, fmt.Errorf("Lengths don't match for sha hash %d != %d", len(hash), len(refHash))
 
 	} else {
-		for i, bt := range hash {
-			refHash[i] = bt
-		}
+		copy(refHash[:], hash)
 	}
 	return refHash, nil
 }


### PR DESCRIPTION
```
pkg/git/git.go:165:3: should use copy() instead of a loop (gosimple)
		for i, bt := range hash {
		^
```

