### PR TITLE
Bump go-playground/webhooks to v6.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/submariner-io/pr-brancher-webhook
 go 1.18
 
 require (
-	github.com/go-playground/webhooks v5.17.0+incompatible
+	github.com/go-playground/webhooks/v6 v6.0.1
 	github.com/google/go-github/v28 v28.1.1
 	github.com/sethvargo/go-password v0.2.0
 	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,9 @@ github.com/go-openapi/jsonreference v0.19.5/go.mod h1:RdybgQwPxbL4UEjuAruzK1x3nE
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.14 h1:gm3vOOXfiuw5i9p5N9xJvfjvuofpyvLA9Wr6QfK5Fng=
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
-github.com/go-playground/webhooks v5.17.0+incompatible h1:Ea3zLJXlnlIFweIujDxdneq512xO4k9cYwAuZ3VuPJo=
-github.com/go-playground/webhooks v5.17.0+incompatible/go.mod h1:rMsxoY7bQzIPF9Ni55rTCyLG2af55f9IWgJ1ao3JiZA=
+github.com/go-playground/webhooks/v6 v6.0.1 h1:ssqgU7vZ+xK+/Uwx4zkf5tfmzOHnLBpzSp5bJ4cX3rg=
+github.com/go-playground/webhooks/v6 v6.0.1/go.mod h1:GCocmfMtpJdkEOM1uG9p2nXzg1kY5X/LtvQgtPHUaaA=
+github.com/gogits/go-gogs-client v0.0.0-20200905025246-8bb8a50cb355/go.mod h1:cY2AIrMgHm6oOHmR7jY+9TtjzSjQ3iG7tURJG3Y6XH0=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -1,7 +1,7 @@
 package handler
 
 import (
-	"github.com/go-playground/webhooks/github"
+	"github.com/go-playground/webhooks/v6/github"
 
 	"github.com/submariner-io/pr-brancher-webhook/pkg/handler/pullrequest"
 )

--- a/pkg/handler/pullrequest/handler.go
+++ b/pkg/handler/pullrequest/handler.go
@@ -5,10 +5,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-playground/webhooks/github"
-	"github.com/submariner-io/pr-brancher-webhook/pkg/config/repoconfig"
+	"github.com/go-playground/webhooks/v6/github"
 	"k8s.io/klog"
 
+	"github.com/submariner-io/pr-brancher-webhook/pkg/config/repoconfig"
 	"github.com/submariner-io/pr-brancher-webhook/pkg/ghclient"
 	"github.com/submariner-io/pr-brancher-webhook/pkg/git"
 )

--- a/pkg/handler/pullrequestreview.go
+++ b/pkg/handler/pullrequestreview.go
@@ -1,12 +1,12 @@
 package handler
 
 import (
-	"github.com/go-playground/webhooks/github"
-	"github.com/submariner-io/pr-brancher-webhook/pkg/config/repoconfig"
-	"github.com/submariner-io/pr-brancher-webhook/pkg/git"
+	"github.com/go-playground/webhooks/v6/github"
 	"k8s.io/klog"
 
+	"github.com/submariner-io/pr-brancher-webhook/pkg/config/repoconfig"
 	"github.com/submariner-io/pr-brancher-webhook/pkg/ghclient"
+	"github.com/submariner-io/pr-brancher-webhook/pkg/git"
 )
 
 func handlePullRequestReview(prr github.PullRequestReviewPayload) error {

--- a/pkg/main/main.go
+++ b/pkg/main/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"net/http"
 
-	"github.com/go-playground/webhooks/github"
+	"github.com/go-playground/webhooks/v6/github"
 	"k8s.io/klog"
 
 	"github.com/submariner-io/pr-brancher-webhook/pkg/config"


### PR DESCRIPTION
Changes:
* https://github.com/go-playground/webhooks/releases/tag/v6.0.0-beta.1
* https://github.com/go-playground/webhooks/releases/tag/v6.0.0-beta.2
* https://github.com/go-playground/webhooks/releases/tag/v6.0.0-beta.3
* https://github.com/go-playground/webhooks/releases/tag/v6.0.1

Signed-off-by: Stephen Kitt <skitt@redhat.com>