### PR TITLE
Add reusable workflow to trigger CodeRabbit review on bot PRs

### DIFF
--- a/.github/workflows/coderabbit-trigger.yml
+++ b/.github/workflows/coderabbit-trigger.yml
@@ -1,0 +1,41 @@
+---
+name: CodeRabbit
+on:
+  workflow_call:
+    inputs:
+      pr_number:
+        required: true
+        type: number
+
+jobs:
+  trigger-coderabbit:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' || github.actor == 'submariner-bot'
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = ${{ inputs.pr_number }};
+
+            const triggerComment = '@coderabbitai review';
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number, per_page: 100 }
+            );
+            const commentExists = comments.some(c => (c.body ?? '').includes(triggerComment));
+
+            if (!commentExists) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body: triggerComment
+              });
+              console.log('CodeRabbit review comment posted.');
+            } else {
+              console.log('CodeRabbit review comment already exists, skipping.');
+            }


### PR DESCRIPTION
CodeRabbit has implicit default behavior that automatically skips bot PRs. The recommended solution is to add a workflow that adds a PR comment to trigger review. This commit adds a reusable workflow that centralizes the logic and can be called from a small workflow in each repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated code review workflow to the CI/CD pipeline that automatically initiates CodeRabbit AI reviews for pull requests when triggered by designated bot accounts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->