### PR TITLE
Adjust the CodeRabbit workflow to always post the comment

### DIFF
--- a/.github/workflows/coderabbit-trigger.yml
+++ b/.github/workflows/coderabbit-trigger.yml
@@ -22,20 +22,10 @@ jobs:
             const issue_number = ${{ inputs.pr_number }};
 
             const triggerComment = '@coderabbitai review';
-            const comments = await github.paginate(
-              github.rest.issues.listComments,
-              { owner, repo, issue_number, per_page: 100 }
-            );
-            const commentExists = comments.some(c => (c.body ?? '').includes(triggerComment));
-
-            if (!commentExists) {
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number,
-                body: triggerComment
-              });
-              console.log('CodeRabbit review comment posted.');
-            } else {
-              console.log('CodeRabbit review comment already exists, skipping.');
-            }
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body: triggerComment
+            });
+            console.log('CodeRabbit review comment posted.');


### PR DESCRIPTION
CodeRabbit posts a comment that it skipped the review and it includes `@coderabbitai review` in the comment which causes the workflow to not post the comment as it checks if already present. So remove the check. It's intended for callers to trigger on opened PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CodeRabbit review automation workflow for improved consistency in posting review comments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->