### PR TITLE
Add CodeRabbit review trigger for Dependabot GitHub Actions updates

### DIFF
--- a/pkg/ghclient/gh.go
+++ b/pkg/ghclient/gh.go
@@ -20,6 +20,7 @@ type GH interface {
 	ApprovePR(prNum int) error
 	CommentOnPR(prNum int, comment string, args ...interface{})
 	EnableAutoMerge(prNum int) error
+	ListFiles(prNum int) ([]*github.CommitFile, error)
 	ListReviews(prNum int) ([]*github.PullRequestReview, error)
 	UpdateDependingPRs(prNum int, baseRef string, branchesToDelete []string) error
 }
@@ -166,6 +167,17 @@ func (gh ghClient) EnableAutoMerge(prNum int) error {
 	}
 
 	return nil
+}
+
+func (gh ghClient) ListFiles(prNum int) ([]*github.CommitFile, error) {
+	files, _, err := gh.client.PullRequests.ListFiles(
+		context.Background(),
+		gh.owner,
+		gh.repo,
+		prNum,
+		&github.ListOptions{PerPage: 100})
+
+	return files, err
 }
 
 func (gh ghClient) ListReviews(prNum int) ([]*github.PullRequestReview, error) {

--- a/pkg/handler/pullrequest/handler.go
+++ b/pkg/handler/pullrequest/handler.go
@@ -85,6 +85,38 @@ func isBotPR(pr *github.PullRequestPayload) bool {
 	return isDependabotPR(pr) || isKonfluxBotPR(pr) || isSubmarinerBotPR(pr)
 }
 
+func isGitHubActionsUpdatePR(pr *github.PullRequestPayload, gh ghclient.GH) bool {
+	// Check if this is a PR targeting the devel branch
+	if pr.PullRequest.Base.Ref != "devel" {
+		return false
+	}
+
+	// Get the list of files changed in the PR
+	files, err := gh.ListFiles(int(pr.Number))
+	if err != nil {
+		klog.Errorf("Error listing files for PR #%d: %s", pr.Number, err)
+		return false
+	}
+
+	// Check if all changed files are GitHub Actions workflow files
+	if len(files) == 0 {
+		return false
+	}
+
+	for _, file := range files {
+		// Check if the file is in .github/workflows/ directory
+		if !strings.HasPrefix(file.GetFilename(), ".github/workflows/") {
+			return false
+		}
+		// Check if it's a YAML file
+		if !strings.HasSuffix(file.GetFilename(), ".yml") && !strings.HasSuffix(file.GetFilename(), ".yaml") {
+			return false
+		}
+	}
+
+	return true
+}
+
 func openOrSync(gitRepo *git.Git, pr *github.PullRequestPayload, gh ghclient.GH) error {
 	prNum := int(pr.Number)
 
@@ -108,6 +140,11 @@ func openOrSync(gitRepo *git.Git, pr *github.PullRequestPayload, gh ghclient.GH)
 				"I will add it automatically once the PR has %d approvals, or you can add it manually.",
 				*config.LabelApproved.Label, *config.LabelApproved.Approvals)
 		}
+	}
+
+	if pr.Action == "opened" && (isSubmarinerBotPR(pr) || (isDependabotPR(pr) && isGitHubActionsUpdatePR(pr, gh))) {
+		klog.Infof("Triggering CodeRabbit review for PR #%d from %s", prNum, pr.PullRequest.User.Login)
+		gh.CommentOnPR(prNum, "@coderabbitai review")
 	}
 
 	if pr.Action == "opened" && isBotPR(pr) {


### PR DESCRIPTION
This commit enhances the webhook bot to automatically trigger CodeRabbit reviews for Dependabot PRs that update GitHub Actions workflow files on the devel branch.

The bot now inspects the files changed in Dependabot PRs targeting the devel branch. If all changed files are GitHub Actions workflow files (.github/workflows/*.yml or *.yaml), it triggers a CodeRabbit review by posting the appropriate comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pull request file listing capability to retrieve changed files
  * Implemented automatic CodeRabbit code reviews for pull requests that exclusively modify GitHub Actions workflow files when opened by authorized bot accounts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->